### PR TITLE
Improve YAML normalisation, mark alertmanager config as sensitive, and add darwin_arm64 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build:
 .PHONY: release
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm

--- a/internal/cortex/resource_alertmanager.go
+++ b/internal/cortex/resource_alertmanager.go
@@ -27,6 +27,7 @@ func resourceAlertmanager() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Content of the Alertmanager configuration.",
 				Required:    true,
+				Sensitive:   true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					olds, err := formatYAML(old)
 					if err != nil {

--- a/internal/cortex/resource_rules.go
+++ b/internal/cortex/resource_rules.go
@@ -37,6 +37,7 @@ func resourceRules() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				DiffSuppressFunc: suppressRuleGroupDiff,
+				StateFunc:        normaliseYAMLState,
 			},
 		},
 	}
@@ -135,7 +136,12 @@ func resourceRulesRead(ctx context.Context, d *schema.ResourceData, m interface{
 		return diag.FromErr(err)
 	}
 
-	d.Set("content", string(out))
+	normalised, err := formatYAML(string(out))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.Set("content", normalised)
 
 	return diags
 }

--- a/internal/cortex/utils.go
+++ b/internal/cortex/utils.go
@@ -21,6 +21,14 @@ func formatYAML(input string) (string, error) {
 	return string(out), nil
 }
 
+func normaliseYAMLState(v interface{}) string {
+	normalised, err := formatYAML(v.(string))
+	if err != nil {
+		return v.(string)
+	}
+	return normalised
+}
+
 func suppressYAMLDiff(_, old, new string, _ *schema.ResourceData) bool {
 	olds, err := formatYAML(old)
 	if err != nil {

--- a/internal/cortex/utils_test.go
+++ b/internal/cortex/utils_test.go
@@ -1,6 +1,7 @@
 package cortex
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -91,4 +92,117 @@ rules:
 			require.Equal(t, test.expectedSuppress, suppressRuleGroupDiff("", test.oldValue, test.newValue, nil))
 		})
 	}
+}
+
+// contentStateValue simulates what Terraform stores in state for the content
+// attribute. If the resource schema has a StateFunc, it is applied (as
+// Terraform would); otherwise the raw value is stored unchanged.
+func contentStateValue(value string) string {
+	sf := resourceRules().Schema["content"].StateFunc
+	if sf != nil {
+		return sf(value)
+	}
+	return value
+}
+
+// TestIdenticalContentProducesIdenticalState verifies that semantically
+// identical YAML written in different key orders produces identical stored
+// state. Without normalisation, struct-marshalled YAML from Read and
+// user-authored YAML from config are stored in different formats, which
+// causes noisy plan diffs whenever a real change exists.
+func TestIdenticalContentProducesIdenticalState(t *testing.T) {
+	// Same content, two different key orders.
+	orderA := "foo: 1\nbar: 2\nbaz: 3\n"
+	orderB := "baz: 3\nfoo: 1\nbar: 2\n"
+
+	require.Equal(t, contentStateValue(orderA), contentStateValue(orderB),
+		"Semantically identical YAML in different key orders must produce identical stored state")
+}
+
+// TestStoredStateIsStable verifies that processing YAML through the state
+// storage path twice produces the same result as once. If the stored form
+// is not stable, each plan/refresh cycle would produce a different state
+// value, causing spurious diffs.
+func TestStoredStateIsStable(t *testing.T) {
+	input := "foo: 1\nbar: 2\nbaz: 3\n"
+
+	first := contentStateValue(input)
+	second := contentStateValue(first)
+	require.Equal(t, first, second,
+		"Storing the same content twice must produce identical state")
+}
+
+// TestSmallChangeProducesSmallDiff verifies that when a single value changes
+// between two differently-ordered YAML documents, the stored state diff
+// contains only the line that actually changed -- not a full rewrite caused
+// by key reordering.
+func TestSmallChangeProducesSmallDiff(t *testing.T) {
+	// Old in one key order, new in a different order with one value changed.
+	old := "alert: test\nexpr: x > 100\nfor: 1m\nlabels:\n  severity: warning\n"
+	new := "labels:\n  severity: warning\nalert: test\nfor: 1m\nexpr: x > 200\n"
+
+	oldState := contentStateValue(old)
+	newState := contentStateValue(new)
+
+	oldLines := strings.Split(strings.TrimSpace(oldState), "\n")
+	newLines := strings.Split(strings.TrimSpace(newState), "\n")
+
+	require.Equal(t, len(oldLines), len(newLines),
+		"Changing one value should not add or remove lines")
+
+	diffCount := 0
+	for i := 0; i < len(oldLines) && i < len(newLines); i++ {
+		if oldLines[i] != newLines[i] {
+			diffCount++
+		}
+	}
+
+	require.Equal(t, 1, diffCount,
+		"Only the changed value should differ, got %d differing lines", diffCount)
+}
+
+// TestArrayOrderIsPreserved verifies that normalisation does not reorder
+// YAML arrays. Array order is semantically significant (e.g., rule
+// evaluation order in Prometheus).
+func TestArrayOrderIsPreserved(t *testing.T) {
+	input := "items:\n  - third\n  - first\n  - second\n"
+
+	state := contentStateValue(input)
+
+	require.Contains(t, state, "- third\n")
+	require.True(t,
+		strings.Index(state, "third") < strings.Index(state, "first") &&
+			strings.Index(state, "first") < strings.Index(state, "second"),
+		"Array element order must be preserved after normalisation")
+}
+
+// TestDeepNestedNormalisation verifies that map key sorting and array order
+// preservation work correctly through multiple levels of nesting.
+func TestDeepNestedNormalisation(t *testing.T) {
+	// Keys deliberately in non-alphabetical order at every level.
+	orderA := `z_outer:
+  z_inner:
+    z_deep: 1
+    a_deep: 2
+  a_inner:
+    value: 3
+a_outer:
+  items:
+    - third
+    - first
+`
+	orderB := `a_outer:
+  items:
+    - third
+    - first
+z_outer:
+  a_inner:
+    value: 3
+  z_inner:
+    a_deep: 2
+    z_deep: 1
+`
+
+	require.Equal(t, contentStateValue(orderA), contentStateValue(orderB),
+		"Deeply nested YAML with different key orders must produce identical stored state")
 }


### PR DESCRIPTION
### YAML normalisation for rule groups

- Add a `StateFunc` (`normaliseYAMLState`) to the `content` attribute of the `cortex_rules` resource, so that YAML is normalised before being stored in Terraform state. This prevents spurious diffs caused by key ordering differences between user-authored YAML and the struct-marshalled YAML returned by the Cortex API.
- Normalise the YAML output in `resourceRulesRead` via `formatYAML` before storing it in state.
- Add `normaliseYAMLState` helper in `utils.go`.
- Add tests covering idempotent state storage, stable round-tripping, minimal diffs for small changes, array order preservation, and deep nested normalisation.

### Mark alertmanager configuration as sensitive 

- Add `Sensitive: true` to the `alertmanager_config` attribute so that its value is redacted in Terraform plan/apply output (backport from [vishmit123 fork](https://github.com/vishmit123/terraform-provider-cortex))

### Add darwin_arm64 to release target

- Add `GOOS=darwin GOARCH=arm64` build to the `release` target in the Makefile, enabling Apple Silicon builds (tested on Go 1.17)
- Fixes #17 